### PR TITLE
Adds support for AWS CLI v2+

### DIFF
--- a/lib/awscli.js
+++ b/lib/awscli.js
@@ -30,6 +30,24 @@ function awsCommand(options) {
  * @return {string} login -u AWS -p <password> https://<account_id>.dkr.ecr.<region>.amazonaws.com
  */
 function getDockerLoginToECRCommand() {
+    const awsCliVersion = awsCommand(['--version']);
+
+    // AWS CLI v2+ doesn't support "get-login" command any more - https://github.com/aws/aws-cli/issues/2875
+    if (awsCliVersion.stdout.trim().indexOf('aws-cli/2') >= 0) {
+        const passwordResult = awsCommand(['ecr', 'get-login-password', '--region', this.options.region]);
+        // Getting account ID
+        const accountIdResult = awsCommand([
+            'sts', 'get-caller-identity',
+            '--region', this.options.region,
+            '--query', 'Account',
+            '--output', 'text',
+            '--profile', this.options.awsProfile,
+        ]);
+
+        return 'login -u AWS -p ' + passwordResult.stdout + ' ' +
+            accountIdResult.stdout.trim() + '.dkr.ecr.' + this.options.region + '.amazonaws.com';
+    }
+
     const result = awsCommand(['ecr', 'get-login', '--region', this.options.region, '--no-include-email']);
     // AWS CLI returns the full command with "docker " out front. Remove it since we don't need it.
     return result.stdout.replace('docker ', '').replace(/[\n\r]/g, '');


### PR DESCRIPTION
This PR adds support for AWS CLI v2+. Since [get-login command is deprecated](https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration.html#cliv2-migration-ecr-get-login) with AWS CLI v2 it fails. Now get-login-password command is used instead.