### PR TITLE
Fixes the BatchJobRole name duplication if the service name is too long.

### DIFF
--- a/lib/batchtask.js
+++ b/lib/batchtask.js
@@ -273,7 +273,7 @@ async function generateLambdaScheduleArtifact(functionName) {
  * Generate Batch job execution role per batch job
  */
 function generateBatchJobExecutionRole(functionName, functionObject) {
-  const batchJobExecutionRoleName = `BatchJobRole-${functionName}-${this.provider.getRegion()}-${this.provider.getStage()}-${this.provider.serverless.service.service}-${functionName}`.substring(0, 64);
+  const batchJobExecutionRoleName = `BatchJobRole-${functionName}-${this.provider.getRegion()}-${this.provider.getStage()}-${this.provider.serverless.service.service}`.substring(0, 64);
   const batchJobExecutionRoleTemplate = `
     {
       "Type": "AWS::IAM::Role",

--- a/lib/batchtask.js
+++ b/lib/batchtask.js
@@ -273,7 +273,7 @@ async function generateLambdaScheduleArtifact(functionName) {
  * Generate Batch job execution role per batch job
  */
 function generateBatchJobExecutionRole(functionName, functionObject) {
-  const batchJobExecutionRoleName = `BatchJobRole-${this.provider.getRegion()}-${this.provider.getStage()}-${this.provider.serverless.service.service}-${functionName}`.substring(0, 64);
+  const batchJobExecutionRoleName = `BatchJobRole-${functionName}-${this.provider.getRegion()}-${this.provider.getStage()}-${this.provider.serverless.service.service}-${functionName}`.substring(0, 64);
   const batchJobExecutionRoleTemplate = `
     {
       "Type": "AWS::IAM::Role",


### PR DESCRIPTION
Hi there!

I have a long service name "companyname-backup-and-restore-test". And the role name is limited with 64 characters, which causes the function name at the end to be stripped. In my case, it causes the duplication of role name if there are more then 1 handler created in serverless.yml.

This fix moves the function name upfront which should address this issue.