### PR TITLE
upgrade nodejs10.x to nodejs12.x

### DIFF
--- a/lib/batchtask.js
+++ b/lib/batchtask.js
@@ -77,7 +77,7 @@ function compileBatchTask(functionName) {
           name: functionObject.name,
           memorySize: 128,
           timeout: 6,
-          runtime: 'nodejs10.x',
+          runtime: 'nodejs12.x',
           package: {
             artifact: `${path.join(this.serverless.config.servicePath, '.serverless', functionName)}.zip`
           },


### PR DESCRIPTION
AWS Lambda has deprecated (and is blocking) deploys using nodejs10.x runtime.
Let me know if anything more should happen.